### PR TITLE
Update UserAgent header to latest Chromium version

### DIFF
--- a/API/shared.js
+++ b/API/shared.js
@@ -54,7 +54,7 @@ module.exports.screnshotForUrlTab = async function (
       //const browser = await puppeteer.launch({args: ['--no-sandbox']});
       const page = await browser.newPage();
       await page.setUserAgent(
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.71 Safari/537.36"
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.159 Safari/537.36"
       );
 
       if (headers != null) {


### PR DESCRIPTION
Hello,

we're getting slightly embarrassing and misleading warnings on our screenshot due to the old user-agent header. Could you merge this to update that?

![image](https://github.com/elestio/ws-screenshot/assets/11933375/6949eab9-a53c-4b7b-a597-ef07899a6929)


Andrew Wichmann