### PR TITLE
Add basic dismissModal argument

### DIFF
--- a/API/REST/Screenshot.js
+++ b/API/REST/Screenshot.js
@@ -78,6 +78,10 @@ exports.handler = async (event, context, callback) => {
       console.error("can't parse headers");
     }
   }
+  var dismissModals = false;
+  if (event.queryStringParameters.dismissModals == "true") {
+    dismissModals = true;
+  }
 
   //var screenshotResult = await tools.screnshotForUrl(url, isFullPage, resX, resY, outFormat);
   var screenshotResult = null;
@@ -92,7 +96,8 @@ exports.handler = async (event, context, callback) => {
       outFormat,
       orientation,
       waitTime,
-      proxy_server
+      proxy_server,
+      dismissModals,
     );
   } catch (ex) {
     //do nothing

--- a/API/WS/Screenshot.js
+++ b/API/WS/Screenshot.js
@@ -76,14 +76,14 @@ exports.message = async (event, context, callback) => {
         screenshotResult = await tools.screnshotForUrlTab(
           url,
           obj.headers,
-          (/true/).test(obj.isFullPage),
+          obj.isFullPage,
           obj.resX,
           obj.resY,
           obj.outFormat,
           obj.orientation,
           obj.waitTime,
           proxy_server,
-          (/true/).test(obj.dismissModals),
+          obj.dismissModals,
         );
       } catch (ex) {
         //do nothing

--- a/API/WS/Screenshot.js
+++ b/API/WS/Screenshot.js
@@ -76,13 +76,14 @@ exports.message = async (event, context, callback) => {
         screenshotResult = await tools.screnshotForUrlTab(
           url,
           obj.headers,
-          obj.isFullPage,
+          (/true/).test(obj.isFullPage),
           obj.resX,
           obj.resY,
           obj.outFormat,
           obj.orientation,
           obj.waitTime,
-          proxy_server
+          proxy_server,
+          (/true/).test(obj.dismissModals),
         );
       } catch (ex) {
         //do nothing

--- a/API/shared.js
+++ b/API/shared.js
@@ -11,7 +11,8 @@ module.exports.screnshotForUrlTab = async function (
   outFormat,
   orientation,
   waitTime,
-  proxy_server
+  proxy_server,
+  dismissModals,
 ) {
   return new Promise(async function (resolve, reject) {
     try {
@@ -81,6 +82,14 @@ module.exports.screnshotForUrlTab = async function (
           timeout: waitTime,
         });
       } catch (ex) {}
+
+      //Try to dismiss modals by sending Tab and Esc
+      if (dismissModals) {
+        try {
+          await page.keyboard.press('Tab');
+          await page.keyboard.press('Escape');
+        } catch (ex) {}
+      }
 
       var finalType = "jpg";
       var finalMime = "image/jpeg";

--- a/API/shared.js
+++ b/API/shared.js
@@ -86,7 +86,7 @@ module.exports.screnshotForUrlTab = async function (
       //Try to dismiss modals by sending Tab and Esc
       if (dismissModals) {
         try {
-          await page.keyboard.press('Tab');
+          await page.focus("body");
           await page.keyboard.press('Escape');
         } catch (ex) {}
       }

--- a/API/shared.js
+++ b/API/shared.js
@@ -88,6 +88,9 @@ module.exports.screnshotForUrlTab = async function (
         try {
           await page.focus("body");
           await page.keyboard.press('Escape');
+          await page.waitForNavigation({
+            timeout: 200,
+          });
         } catch (ex) {}
       }
 

--- a/public/client.js
+++ b/public/client.js
@@ -83,10 +83,20 @@ function connect() {
 }
 
 var sendQueue = [];
-function AskForScreenshot(url, resX, resY, outFormat, isFullPage, waitTime){    
+function AskForScreenshot(url, resX, resY, outFormat, isFullPage, waitTime, dismissModals){    
     $("#resultImg").hide();
     $("#stats").html("Please wait ...");
-    var event = { cmd: "screenshot", url: url, originalTS: (+new Date()), resX: resX, resY: resY, outFormat: outFormat, isFullPage: isFullPage, waitTime: waitTime };
+    var event = { 
+        cmd: "screenshot",
+        url: url,
+        originalTS: (+new Date()),
+        resX: resX,
+        resY: resY,
+        outFormat: outFormat,
+        isFullPage: isFullPage,
+        waitTime: waitTime,
+        dismissModals: dismissModals,
+    };
     Send(event);
 }
 
@@ -128,6 +138,7 @@ function UpdateRESTUrl(){
     baseUrl += "&outFormat=" + $("#outFormat").val();
     baseUrl += "&waitTime=" + $("#waitTime").val();
     baseUrl += "&isFullPage=" + document.getElementById("isFullPage").checked;
+    baseUrl += "&dismissModals=" + document.getElementById("dismissModals").checked;
 
     if ( $("#fieldUrl").val().indexOf("&") > -1 ){
         baseUrl += "&url=" + encodeURIComponent( $("#fieldUrl").val() )

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -93,7 +93,7 @@ h1 {
     margin-right: 5px;
 }
 
-.screenshot__wait-time, .screenshot__full-page {
+.screenshot__wait-time, .screenshot__full-page, .screenshot__dismiss-modals {
     margin-left: 25px;
     margin-right: 5px;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -57,6 +57,7 @@
                         </select>
                     </div>
                     <input class="screenshot__full-page" id="isFullPage" type="checkbox" onchange="UpdateRESTUrl()"> Full page screenshot
+                    <input class="screenshot__dismiss-modals" id="dismissModals" type="checkbox" onchange="UpdateRESTUrl()"> Dismiss modals
                     <div class="left screenshot__wait-time">
                         <span>Wait time before screenshot </span>  <input class="screenshot__input-options mleft-5" id="waitTime" type="number" min="0" max="30000" value="100" onchange="UpdateRESTUrl()"> ms
                     </div>
@@ -93,8 +94,8 @@
         var outFormat = document.getElementById("outFormat").value;
         var isFullPage = document.getElementById("isFullPage").checked;
         var waitTime = document.getElementById("waitTime").value;
-        
-        AskForScreenshot(url, resX, resY, outFormat, isFullPage, waitTime);
+        var dismissModals = document.getElementById("dismissModals").checked;
+        AskForScreenshot(url, resX, resY, outFormat, isFullPage, waitTime, dismissModals);
     }
 
 </script>


### PR DESCRIPTION
This tries to dismiss any modals.

In a basic attempt it tries focusing the page, pressing escape, and then waiting 200ms for any animations to clear. In testing various URLs this seems to work quite well. Especially for pages that ask you to login on page load. For example, facebook.com

Here is an example:
[Screencast from 2023-12-15 13-45-42.webm](https://github.com/elestio/ws-screenshot/assets/3289919/83cf4262-ceff-433a-b12c-20608920eab2)

